### PR TITLE
Accept YML files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.idea

--- a/src/main/java/imconfig/Config.java
+++ b/src/main/java/imconfig/Config.java
@@ -58,6 +58,8 @@ public interface Config {
     /** @return <code>true</code> if there is a multi-valued property with the given key */
     boolean hasMultivaluedProperty(String key);
 
+    /** @return the current key */
+    String key();
 
     /** @return An iterable object over all the keys of the configuration,
      *  even for those which have no value */

--- a/src/main/java/imconfig/internal/EmptyConfig.java
+++ b/src/main/java/imconfig/internal/EmptyConfig.java
@@ -51,6 +51,10 @@ public class EmptyConfig implements Config {
         return false;
     }
 
+    @Override
+    public String key() {
+        return null;
+    }
 
     @Override
     public Iterable<String> keys() {

--- a/src/main/java/imconfig/internal/ExternalReaderFactory.java
+++ b/src/main/java/imconfig/internal/ExternalReaderFactory.java
@@ -21,7 +21,7 @@ public class ExternalReaderFactory {
                 return externalReaders.computeIfAbsent(extension, x->newJsonReader());
             case "xml":
                 return externalReaders.computeIfAbsent(extension, x->newXmlReader());
-            case "yaml":
+            case "yaml": case "yml":
                 return externalReaders.computeIfAbsent(extension, x->newYamlReader());
             case "toml":
                 return externalReaders.computeIfAbsent(extension, x->newTomlReader());

--- a/src/main/java/imconfig/internal/MapBasedConfig.java
+++ b/src/main/java/imconfig/internal/MapBasedConfig.java
@@ -8,15 +8,26 @@ import java.util.stream.*;
 @SuppressWarnings("unchecked")
 public class MapBasedConfig extends AbstractConfig {
 
+    private final String key;
     private final Map<String,?> values;
 
     MapBasedConfig(
         ConfigFactory builder,
         Map<String,?> values,
-        Map<String,PropertyDefinition> definitions
+        Map<String,PropertyDefinition> definitions,
+        String key
     ) {
         super(builder, definitions);
         this.values = Map.copyOf(values);
+        this.key = key;
+    }
+
+    MapBasedConfig(
+            ConfigFactory builder,
+            Map<String,?> values,
+            Map<String,PropertyDefinition> definitions
+    ) {
+        this(builder,values, definitions, "");
     }
 
     MapBasedConfig(
@@ -57,9 +68,10 @@ public class MapBasedConfig extends AbstractConfig {
 
     @Override
     public Config inner(String keyPrefix) {
-        return this
-            .filtered(it -> it.startsWith(keyPrefix+"."))
-            .alteringKeys(it -> it.substring(it.indexOf(keyPrefix+".")+keyPrefix.length()+1));
+        Config newConfig = this
+                .filtered(it -> it.startsWith(keyPrefix+"."))
+                .alteringKeys(it -> it.substring(it.indexOf(keyPrefix+".")+keyPrefix.length()+1));
+        return new MapBasedConfig(builder, newConfig.asMap(), definitions, key.isEmpty() ? keyPrefix : key + "." + keyPrefix);
     }
 
 
@@ -80,6 +92,10 @@ public class MapBasedConfig extends AbstractConfig {
         return values.get(key) instanceof List;
     }
 
+    @Override
+    public String key() {
+        return key;
+    }
 
     @Override
     public Iterable<String> keys() {

--- a/src/test/java/imconfig/test/TestConfigurationFactory.java
+++ b/src/test/java/imconfig/test/TestConfigurationFactory.java
@@ -31,6 +31,7 @@ public class TestConfigurationFactory {
     private static final String KEY_ENV = "test.env.key";
     private static final String VAL_ENV = "Test Environment Value";
 
+    private static final String KEY_PROPERTIES = "properties.test.key";
     private static final String KEY_STRING = "properties.test.key.string";
     private static final String KEY_STRINGS = "properties.test.key.strings";
     private static final String KEY_BOOL = "properties.test.key.bool";
@@ -441,6 +442,8 @@ public class TestConfigurationFactory {
             );
 
         assertNullProperties(conf);
+        Assertions.assertThat(conf.inner(KEY_ENV).key()).isEqualTo(KEY_ENV);
+        Assertions.assertThat(conf.inner(KEY_PROPERTIES).inner("string").key()).isEqualTo(KEY_STRING);
     }
 
 

--- a/src/test/java/imconfig/test/TestConfigurationFactory.java
+++ b/src/test/java/imconfig/test/TestConfigurationFactory.java
@@ -148,6 +148,13 @@ public class TestConfigurationFactory {
 
 
     @Test
+    public void createConfigurationFromYMLFile() {
+        Config conf = factory.fromResource("test-conf.yml", UTF8, CLASS_LOADER);
+        assertExpectedPropertiesExist(conf);
+    }
+
+
+    @Test
     public void createConfigurationFromPropertiesFile() throws ConfigException {
         Config conf = factory.fromResource("test-conf.properties", UTF8, CLASS_LOADER);
         assertExpectedPropertiesExist(conf);

--- a/src/test/java/imconfig/test/TestConfigurationFactoryDefinitions.java
+++ b/src/test/java/imconfig/test/TestConfigurationFactoryDefinitions.java
@@ -9,6 +9,7 @@ import java.nio.charset.StandardCharsets;
 import org.junit.Test;
 
 import java.nio.file.Path;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -17,26 +18,32 @@ public class TestConfigurationFactoryDefinitions {
 
 
     private final ConfigFactory factory = ConfigFactory.instance();
-    private final Path definitionPath = Path.of("src", "test", "resources", "definition.yaml");
+    private final Path basePath = Path.of("src", "test", "resources");
 
 
     @Test
     public void testBuildEmptyConfigurationWithDefinitionFromURI() {
-        var conf = factory.accordingDefinitionsFromURI(definitionPath.toUri(), StandardCharsets.UTF_8);
-        assertConfiguration(conf);
+        for (Path definitionPath : List.of(
+                basePath.resolve("definition.yaml"), basePath.resolve("definition.yml"))) {
+            var conf = factory.accordingDefinitionsFromURI(definitionPath.toUri(), StandardCharsets.UTF_8);
+            assertConfiguration(conf);
+        }
     }
 
     @Test
     public void testBuildEmptyConfigurationWithDefinitionFromPath() {
-        var conf = factory.accordingDefinitionsFromPath(definitionPath, StandardCharsets.UTF_8);
-        assertConfiguration(conf);
+        for (Path definitionPath : List.of(
+                basePath.resolve("definition.yaml"), basePath.resolve("definition.yml"))) {
+            var conf = factory.accordingDefinitionsFromPath(definitionPath, StandardCharsets.UTF_8);
+            assertConfiguration(conf);
+        }
     }
 
 
     @Test
     public void testAttachDefinitionFromURI() {
         var conf = factory.empty()
-            .append(factory.accordingDefinitionsFromURI(definitionPath.toUri(), StandardCharsets.UTF_8));
+            .append(factory.accordingDefinitionsFromURI(basePath.resolve("definition.yaml").toUri(), StandardCharsets.UTF_8));
         assertConfiguration(conf);
     }
 
@@ -44,7 +51,7 @@ public class TestConfigurationFactoryDefinitions {
     @Test
     public void testAttachDefinitionFromPath() {
         var conf = factory.empty()
-            .append(factory.accordingDefinitionsFromPath(definitionPath, StandardCharsets.UTF_8));
+            .append(factory.accordingDefinitionsFromPath(basePath.resolve("definition.yaml"), StandardCharsets.UTF_8));
         assertConfiguration(conf);
     }
 
@@ -53,7 +60,7 @@ public class TestConfigurationFactoryDefinitions {
     public void testConfigurationValidation() {
         var conf = factory
             .fromPairs("defined.property.min-max-number", "6")
-            .append(factory.accordingDefinitionsFromPath(definitionPath,StandardCharsets.UTF_8));
+            .append(factory.accordingDefinitionsFromPath(basePath.resolve("definition.yaml"),StandardCharsets.UTF_8));
         assertThat(conf.validations("defined.property.min-max-number"))
         .contains("Invalid value '6', expected: Integer number between 2 and 3");
     }

--- a/src/test/resources/definition.yml
+++ b/src/test/resources/definition.yml
@@ -1,0 +1,31 @@
+defined.property.required:
+   description: This is a test property that is required
+   required: true
+   type: text
+
+defined.property.with-default-value:
+   description: This is a property with a default value
+   type: integer
+   defaultValue: 5
+
+defined.property.regex-text:
+   type: text
+   constraints:
+      pattern: A\d\dB
+
+defined.property.min-max-number:
+   type: integer
+   constraints:
+      min: 2
+      max: 3
+
+defined.property.enumeration:
+   type: enum
+   constraints:
+      values:
+         - red
+         - yellow
+         - orange
+
+defined.property.boolean:
+   type: boolean

--- a/src/test/resources/test-conf.yml
+++ b/src/test/resources/test-conf.yml
@@ -1,0 +1,42 @@
+properties:
+  test:
+    key:
+      string: Properties Test String Value
+      strings:
+       - Properties Array Value 1
+       - Properties Array Value 2
+      bool: true
+      bools:
+       - true
+       - false
+       - true
+      integer: 77
+      integers:
+       - 77
+       - 79
+       - 83
+      long: 54353
+      longs:
+       - 54353
+       - 65256
+       - 98432
+      double: 3.45
+      doubles:
+       - 3.45
+       - 6.76
+       - 9.32
+      float: 6.98
+      floats:
+       - 6.98
+       - 2.23
+       - 1.24
+      bigdecimal: 755.87
+      bigdecimals:
+       - 755.87
+       - 876.43
+       - 908.32       
+      biginteger: 123456789
+      bigintegers:
+       - 123456789
+       - 543987532
+       - 549874348 


### PR DESCRIPTION
It can now also read files with an `yml` extension.
Related issue: https://github.com/iti-ict/wakamiti/issues/134

Extra:
- Config current key info added: When a new configuration is created from a key prefix using the inner method, that prefix is stored in the new configuration, so we know where we are.